### PR TITLE
Fix setup process

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ config = {
     'platforms': ['Linux'],
     'license': 'MIT',
     'install_requires': ['pyserial >= 3.0'],
+    'packages': ['thermalprinter'],
 }
 
 setup(**config)


### PR DESCRIPTION
The setup process wasn't actually installing/copying the library to the pythonpath. Adding the packages list should fix this. (And also fix pip installation, which had the same problem)

