### PR TITLE
Greek characters print example

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -8,3 +8,6 @@
 
 Phillip 'vIiRuS' Thelen [http://pherth.net]
     - Fix setup installation
+
+Alexandros Kokkalas
+    -Print Greek Characters

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ An example is better than thousand words:
         printer.out('现代汉语通用字表', chinese=True,
                     chinese_format=Chinese.UTF_8)
                     
-        # Greek 
+        # Greek (excepted the ΐ character)
         printer.out('Στην υγειά μας!', codepage=CodePage.CP737)
 
         # Accents

--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,9 @@ An example is better than thousand words:
         # Chinese (almost all alphabets exist)
         printer.out('现代汉语通用字表', chinese=True,
                     chinese_format=Chinese.UTF_8)
+                    
+        # Greek 
+        printer.out('Στην υγειά μας!', codepage=CodePage.CP737)
 
         # Accents
         printer.out('Voilà !', justify='C', strike=True,


### PR DESCRIPTION
Can print all Greek characters except : ΐ