### PR TITLE
Add option to specify command timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.3.0
+
+### Features
+
+- Add option to specify command timeout.
 ## 0.2.0
 
 Release date: `2019-01-10`

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -23,6 +23,7 @@ Class
             - ``heat_time`` (int): printer heat time (default: ``80``);
             - ``heat_interval`` (int): printer heat time interval (default: ``12``);
             - ``most_heated_point`` (int): for the printer, the most heated point (default: ``3``).
+            - ``command_timeout`` (int): command timeout (default: ``0.05``).
 
         :exception ThermalPrinterValueError: On incorrect argument's type or value.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = thermalprinter
-version = 0.2.1
+version = 0.3.0
 author = Mickaël 'Tiger-222' Schoentgen
 author-email = contact@tiger-222.fr
 description = Driver for the DP-EH600 thermal printer (AdaFruit).

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = thermalprinter
-version = 0.2.0
+version = 0.2.1
 author = Mickaël 'Tiger-222' Schoentgen
 author-email = contact@tiger-222.fr
 description = Driver for the DP-EH600 thermal printer (AdaFruit).

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -21,9 +21,9 @@ def methods():
     "method, arguments",
     [
         ("__enter__", {}),
-        ("__init__", {"args": ["self", "port", "baudrate"],
+        ("__init__", {"args": ["self", "port", "baudrate", "command_timeout"],
                       "varkw": "kwargs",
-                      "defaults": ("/dev/ttyAMA0", 19200)}),
+                      "defaults": ("/dev/ttyAMA0", 19200, 0.05)}),
         ("__repr__", {}),
         ("_on_exit", {}),
         ("barcode", {"args": ["self", "data", "barcode_type"]}),

--- a/thermalprinter/__init__.py
+++ b/thermalprinter/__init__.py
@@ -19,7 +19,7 @@ from .constants import (BarCode, BarCodePosition, CharSet, Chinese, CodePage,
 from .exceptions import ThermalPrinterError
 from .thermalprinter import ThermalPrinter
 
-__version__ = '0.2.0'
+__version__ = '0.3.0'
 __author__ = 'Mickaël Schoentgen'
 __copyright__ = """
     Copyright (c) 2016-2020, Mickaël 'Tiger-222' Schoentgen

--- a/thermalprinter/thermalprinter.py
+++ b/thermalprinter/thermalprinter.py
@@ -30,7 +30,7 @@ class ThermalPrinter(Serial):
     __lines = 0
     __feeds = 0
 
-    def __init__(self, port='/dev/ttyAMA0', baudrate=19200, **kwargs):
+    def __init__(self, port='/dev/ttyAMA0', baudrate=19200, command_timeout=0.05, **kwargs):
         """ Print init. """
 
         self.heat_time = int(kwargs.get('heat_time', 80))
@@ -53,6 +53,7 @@ class ThermalPrinter(Serial):
         self._byte_time = 11.0 / float(self._baudrate)
         self._dot_feed_time = 0.0025
         self._dot_print_time = 0.033
+        self._command_timeout = command_timeout
 
         # Init the serial
         super().__init__(port=port, baudrate=self._baudrate)
@@ -319,7 +320,7 @@ class ThermalPrinter(Serial):
             self._codepage = codepage
             value, _ = codepage.value
             self.send_command(Command.ESC, 116, value)
-            sleep(0.05)
+            sleep(self._command_timeout)
 
     def double_height(self, state=False):
         """ Set double height mode. """
@@ -358,7 +359,7 @@ class ThermalPrinter(Serial):
 
         self.send_command(Command.ESC, 64)
         self.reset_output_buffer()
-        sleep(0.05)
+        sleep(self._command_timeout)
         if clear:
             self.reset_input_buffer()
 
@@ -579,7 +580,7 @@ class ThermalPrinter(Serial):
         ret = {'movement': True, 'paper': True,
                'temp': True, 'voltage': True}
         self.send_command(Command.ESC, 118, 0)
-        sleep(0.05)
+        sleep(self._command_timeout)
         if self.in_waiting:
             stat = ord(self.read(1))
             ret['movement'] = stat & 0b00000001 == 1
@@ -635,5 +636,5 @@ class ThermalPrinter(Serial):
         if self.is_sleeping:
             self.__is_sleeping = False
             self.send_command(255)
-            sleep(0.05)    # Sleep 50ms as in documentation
+            sleep(self._command_timeout)    # Sleep 50ms as in documentation
             self.sleep(0)  # SLEEP OFF - IMPORTANT!


### PR DESCRIPTION
I've been working with `DP-EH400/1` printer, and I observed response times above 50ms, sometimes reaching 80ms. 
![image](https://user-images.githubusercontent.com/490844/171614631-d4a3d3fe-28f1-41c5-b9c1-e19da356a2d2.png)
This PR allows for specifying custom timeout value. 